### PR TITLE
fix: old imports

### DIFF
--- a/bench/init.luau
+++ b/bench/init.luau
@@ -70,13 +70,13 @@ end
 
 print("Running benchmarks to warm up...")
 
-run(bytecode_runner, lossless_bytecode_parser, fs.readFile("lib/lossless.luau"), "lossless.luau")
+run(bytecode_runner, lossless_bytecode_parser, lossless_source, "lossless.luau")
 
 for _, name in fs.readDir("bench/cases") do
 	run(bytecode_runner, lossless_bytecode_parser, fs.readFile(`bench/cases/{name}`), name)
 end
 
-run(native_runner, lossless_native_parser, fs.readFile("lib/lossless.luau"), "lossless.luau")
+run(native_runner, lossless_native_parser, lossless_source, "lossless.luau")
 
 for _, name in fs.readDir("bench/cases") do
 	run(native_runner, lossless_native_parser, fs.readFile(`bench/cases/{name}`), name)
@@ -86,7 +86,7 @@ output = {}
 
 print("Running bytecode benchmarks...")
 
-run(bytecode_runner, lossless_bytecode_parser, fs.readFile("lib/lossless.luau"), "lossless.luau")
+run(bytecode_runner, lossless_bytecode_parser, lossless_source, "lossless.luau")
 
 for _, name in fs.readDir("bench/cases") do
 	run(bytecode_runner, lossless_bytecode_parser, fs.readFile(`bench/cases/{name}`), name)
@@ -97,7 +97,7 @@ output = {}
 
 print("Running native benchmarks...")
 
-run(native_runner, lossless_native_parser, fs.readFile("lib/lossless.luau"), "lossless.luau")
+run(native_runner, lossless_native_parser, lossless_source, "lossless.luau")
 
 for _, name in fs.readDir("bench/cases") do
 	run(native_runner, lossless_native_parser, fs.readFile(`bench/cases/{name}`), name)


### PR DESCRIPTION
These imports seems to be stale after project structure update. 
I'm also not sure why the file is read anew everytime and not reused 🤔 

To run the benchmarks as stated in the readme I also had to update imports in `parser.luau` to
```
local cst = require("lossless/cst")
local span = require("lossless/span")
```

but I don't think it's a correct solution, Maybe adding `init.lua` to `lossless` is a better way 🤔 